### PR TITLE
Patch 2.0.0: require zarr >=3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     - cd icechunk-python
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -33,7 +33,7 @@ requirements:
     - pip
   run:
     - python
-    - zarr >=3  # [not aarch64]
+    - zarr >=3.1  # [not aarch64]
 
 test:
   imports:


### PR DESCRIPTION
## Summary
- Tighten zarr dependency from `>=3` to `>=3.1` for icechunk 2.0.0
- Bump build number to 1 to trigger a rebuild with the corrected pin

## Test plan
- [ ] CI builds pass with updated dependency
- [ ] Verify the rebuilt package installs zarr >=3.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)