### PR TITLE
Update zarr dependency to >=3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pip
   run:
     - python
-    - zarr >=3  # [not aarch64]
+    - zarr >=3.1  # [not aarch64]
 
 test:
   imports:


### PR DESCRIPTION
## Summary
- icechunk 2.0.x requires zarr >=3.1, not >=3
- Updates the recipe so future builds have the correct pin
- Existing published packages are being patched via conda-forge/conda-forge-repodata-patches-feedstock#1188

## Test plan
- [ ] CI builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)