### PR TITLE
Update zarr dependency to >=3.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     - cd icechunk-python
     - {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - pip
   run:
     - python
-    - zarr >=3  # [not aarch64]
+    - zarr >=3.1  # [not aarch64]
 
 test:
   imports:


### PR DESCRIPTION
## Summary
- icechunk 2.0.x requires zarr >=3.1, not >=3
- Updates the recipe so future builds have the correct pin
- Existing published packages are being patched via conda-forge/conda-forge-repodata-patches-feedstock#1188

Checklist before merging this PR:
- [x] Dependencies have been updated if changed: see [upstream](https://github.com/earth-mover/icechunk)
- [x] Tests have passed 
- [x] Updated license if changed and `license_file` is packaged 

🤖 Generated with [Claude Code](https://claude.com/claude-code)